### PR TITLE
Migrate plugin to QGIS 4.0 / Qt6 / PyQt6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,5 +163,9 @@ cython_debug/
 carto.zip
 carto/.DS_Store
 carto/gui/.DS_Store
+.DS_Store
 
 *.zip
+
+# AI tool local settings
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,31 @@
+# CARTO QGIS Plugin
+
+A QGIS plugin to access, visualize, and edit geospatial data in cloud data warehouses (BigQuery, Snowflake, Databricks, Redshift, PostgreSQL) via CARTO.
+
+## Tech stack
+
+- Python 3.7+
+- QGIS API (`qgis.core`, `qgis.gui`)
+- Qt via `qgis.PyQt` (not direct PyQt5/PyQt6 imports)
+
+## Project structure
+
+- `carto/` — plugin source (symlinked into QGIS plugins dir for development)
+  - `core/` — API client, auth, connections, layer download/import, logging
+  - `gui/` — Qt dialogs (.ui + Python), data provider, settings, SSO
+  - `libs/` — vendored dependencies (json2html)
+  - `plugin.py` — main entry point
+- `helper.py` — dev tooling: install, package, publish
+
+## Development
+
+```sh
+python helper.py install   # symlink to QGIS plugins dir
+python helper.py package   # build carto.zip for distribution
+```
+
+## Code formatting
+
+- Black (default settings, Python 3.7+ target)
+- isort with `profile = black`
+- flake8 with `max-line-length = 99`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ A QGIS plugin to access, visualize, and edit geospatial data in cloud data wareh
 
 ## Tech stack
 
-- Python 3.7+
+- Python 3.12+
 - QGIS API (`qgis.core`, `qgis.gui`)
 - Qt via `qgis.PyQt` (not direct PyQt5/PyQt6 imports)
 
@@ -26,6 +26,6 @@ python helper.py package   # build carto.zip for distribution
 
 ## Code formatting
 
-- Black (default settings, Python 3.7+ target)
+- Black (default settings, Python 3.12+ target)
 - isort with `profile = black`
 - flake8 with `max-line-length = 99`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,11 +12,11 @@ To install the latest version from this repository, follow these steps:
 $ git clone https://github.com/cartodb/carto-qgis-plugin.git
 ```
 
--   Create a link between the repository folder and the QGIS 3 plugins folder.
+-   Create a link between the repository folder and the QGIS 4 plugins folder.
 
 ```console
 $ cd carto-qgis-plugin
-$ python helper.py install
+$ python helper.py install --qgis4
 ```
 
 -   Start QGIS and you will find the plugin in the plugins menu. If it's not available yet, activate
@@ -39,6 +39,6 @@ We use [Black](https://github.com/psf/black) to ensure consistent code formattin
 -   Sublime Text: install [sublack](https://packagecontrol.io/packages/sublack) via Package Control
 -   VSCode [instructions](https://code.visualstudio.com/docs/python/editing#_formatting)
 
-We use the default settings, and target python 3.7+.
+We use the default settings, and target python 3.12+.
 
 One easy solution is to install [pre-commit](https://pre-commit.com), run `pre-commit install --install-hooks` and it'll automatically validate your changes code as a git pre-commit hook.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CARTO QGIS Plugin
 
-A [QGIS](https://qgis.org) plugin plugin to access, visualize, and edit geospatial data in your data warehouse via [CARTO](https://carto.com).
+A [QGIS](https://qgis.org) plugin to access, visualize, and edit geospatial data in your data warehouse via [CARTO](https://carto.com).
 
 [![License: GPL v2](https://img.shields.io/badge/License-GPLv2-blue.svg)](./LICENSE.md)
 
@@ -8,7 +8,7 @@ A [QGIS](https://qgis.org) plugin plugin to access, visualize, and edit geospati
 
 The CARTO plugin is available in the [QGIS Plugins Repository](https://plugins.qgis.org/plugins/carto/). To install the latest version, use the QGIS Plugin Manager and search for the CARTO QGIS plugin.
 
-This plugin is compatible with QGIS v3.16 or later.
+This plugin is compatible with QGIS v4.0 or later. For QGIS 3.x, use [v0.92.4](https://github.com/cartodb/carto-qgis-plugin/releases/tag/v0.92.4).
 
 ## Contributing
 

--- a/carto/core/auth.py
+++ b/carto/core/auth.py
@@ -61,7 +61,7 @@ class CallbackHandler(BaseHTTPRequestHandler):
 
                 network_request = QNetworkRequest(QUrl(TOKEN_URL))
                 network_request.setHeader(
-                    QNetworkRequest.ContentTypeHeader,
+                    QNetworkRequest.KnownHeaders.ContentTypeHeader,
                     "application/x-www-form-urlencoded",
                 )
 

--- a/carto/core/connection.py
+++ b/carto/core/connection.py
@@ -217,13 +217,13 @@ class Schema:
         def _show_terminated_message():
             iface.messageBar().pushMessage(
                 f"Importing to {fqn} failed or was canceled",
-                level=Qgis.Warning,
+                level=Qgis.MessageLevel.Warning,
                 duration=5,
             )
 
         def _show_completed_message():
             iface.messageBar().pushMessage(
-                f"Layer correctly imported to {fqn}", level=Qgis.Success, duration=5
+                f"Layer correctly imported to {fqn}", level=Qgis.MessageLevel.Success, duration=5
             )
             self.clear_tables_cache()
 
@@ -237,7 +237,7 @@ class Schema:
         iface.messageBar().pushMessage(
             "",
             "Import task added to QGIS task manager",
-            level=Qgis.Info,
+            level=Qgis.MessageLevel.Info,
             duration=5,
         )
 

--- a/carto/core/downloadtabletask.py
+++ b/carto/core/downloadtabletask.py
@@ -36,7 +36,7 @@ from qgis.core import (
 )
 
 
-from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtCore import QMetaType
 
 
 class DownloadTableTask(QgsTask):
@@ -112,11 +112,11 @@ class DownloadTableTask(QgsTask):
                         field_name = field["name"]
                         field_type = field["type"]
                         if field_type == "string":
-                            fields.append(QgsField(field_name, QVariant.String))
+                            fields.append(QgsField(field_name, QMetaType.Type.QString))
                         elif field_type in ["integer", "int", "bigint"]:
-                            fields.append(QgsField(field_name, QVariant.Int))
+                            fields.append(QgsField(field_name, QMetaType.Type.Int))
                         elif field_type in ["double", "number", "float"]:
-                            fields.append(QgsField(field_name, QVariant.Double))
+                            fields.append(QgsField(field_name, QMetaType.Type.Double))
                         elif field_type == "geometry":
                             geom_field = field_name
                     provider_type = self.table.schema.database.connection.provider_type

--- a/carto/core/importlayertask.py
+++ b/carto/core/importlayertask.py
@@ -12,7 +12,7 @@ from carto.core.utils import (
 )
 from carto.core.api import CARTO_API
 
-from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtCore import QMetaType
 
 
 class ImportLayerTask(QgsTask):
@@ -66,7 +66,7 @@ class ImportLayerTask(QgsTask):
                         field_values.append("NULL")
                     elif field.isNumeric():
                         field_values.append(str(value))
-                    elif field.type() == QVariant.Bool:
+                    elif field.type() == QMetaType.Type.Bool:
                         field_values.append("TRUE" if value else "FALSE")
                     else:
                         field_values.append(f"'{value}'")

--- a/carto/core/layers.py
+++ b/carto/core/layers.py
@@ -124,7 +124,7 @@ class LayerTracker:
         if not can_write(layer):
             iface.messageBar().pushMessage(
                 "No permission to write. Local changes will not be saved to the original table",
-                level=Qgis.Warning,
+                level=Qgis.MessageLevel.Warning,
                 duration=5,
             )
             return
@@ -138,7 +138,7 @@ class LayerTracker:
         if metadata["schema_changed"]:
             iface.messageBar().pushMessage(
                 "Table schema has changed: changes will not be uploaded upstream",
-                level=Qgis.Warning,
+                level=Qgis.MessageLevel.Warning,
                 duration=5,
             )
             return
@@ -150,8 +150,8 @@ class LayerTracker:
         if not pk_field:
             dialog = SelectPrimaryKeyDialog(original_columns)
             try:
-                QApplication.setOverrideCursor(Qt.ArrowCursor)
-                dialog.exec_()
+                QApplication.setOverrideCursor(Qt.CursorShape.ArrowCursor)
+                dialog.exec()
             finally:
                 QApplication.restoreOverrideCursor()
             if dialog.pk:
@@ -161,7 +161,7 @@ class LayerTracker:
             else:
                 iface.messageBar().pushMessage(
                     "Layer has no Primary Key: changes will not be uploaded upstream",
-                    level=Qgis.Warning,
+                    level=Qgis.MessageLevel.Warning,
                     duration=5,
                 )
                 return
@@ -251,12 +251,12 @@ class LayerTracker:
             for statement in sql:
                 CARTO_API.execute_query(connection, statement)
             iface.messageBar().pushMessage(
-                "Layer changes uploaded", level=Qgis.Success, duration=5
+                "Layer changes uploaded", level=Qgis.MessageLevel.Success, duration=5
             )
         except Exception as e:
             iface.messageBar().pushMessage(
                 "Error uploading changes: changes could not be made in the upstream table",
-                level=Qgis.Critical,
+                level=Qgis.MessageLevel.Critical,
                 duration=5,
             )
             error("Error uploading changes: " + str(e))

--- a/carto/core/logging.py
+++ b/carto/core/logging.py
@@ -4,7 +4,7 @@ DEBUG = True
 MAX_LINES = 20
 
 
-def _log(msg, level=Qgis.Info):
+def _log(msg, level=Qgis.MessageLevel.Info):
     lines = msg.splitlines()
     if len(lines) > 20:
         msg = "\n".join(lines[:20]) + f"\n[Showing only the first {MAX_LINES} lines]"
@@ -12,11 +12,11 @@ def _log(msg, level=Qgis.Info):
 
 
 def info(msg):
-    _log(msg, Qgis.Info)
+    _log(msg, Qgis.MessageLevel.Info)
 
 
 def error(msg):
-    _log(msg, Qgis.Critical)
+    _log(msg, Qgis.MessageLevel.Critical)
 
 
 def debug(msg):

--- a/carto/core/utils.py
+++ b/carto/core/utils.py
@@ -3,7 +3,7 @@ import requests
 import shutil
 from carto.gui.utils import waitcursor
 
-from qgis.PyQt.QtCore import QSettings, QVariant
+from qgis.PyQt.QtCore import QSettings, QMetaType
 from qgis.core import (
     NULL,
     QgsMessageLog,
@@ -108,44 +108,44 @@ def provider_data_type_from_qgis_type(qgis_type, provider):
 
     type_mapping = {
         "bigquery": {
-            QVariant.String: "STRING",
+            QMetaType.Type.QString: "STRING",
             "text": "STRING",
-            QVariant.Int: "INT64",
-            QVariant.LongLong: "INT64",
-            QVariant.Double: "FLOAT64",
-            QVariant.Bool: "BOOL",
+            QMetaType.Type.Int: "INT64",
+            QMetaType.Type.LongLong: "INT64",
+            QMetaType.Type.Double: "FLOAT64",
+            QMetaType.Type.Bool: "BOOL",
             "geometry": "GEOGRAPHY",
         },
         "snowflake": {
-            QVariant.String: "VARCHAR",
-            QVariant.Int: "NUMBER(38,0)",
-            QVariant.LongLong: "NUMBER(38,0)",
-            QVariant.Double: "FLOAT",
-            QVariant.Bool: "BOOL",
+            QMetaType.Type.QString: "VARCHAR",
+            QMetaType.Type.Int: "NUMBER(38,0)",
+            QMetaType.Type.LongLong: "NUMBER(38,0)",
+            QMetaType.Type.Double: "FLOAT",
+            QMetaType.Type.Bool: "BOOL",
             "geometry": "GEOGRAPHY",
         },
         "redshift": {
-            QVariant.String: "VARCHAR(MAX)",
-            QVariant.Int: "BIGINT",
-            QVariant.LongLong: "BIGINT",
-            QVariant.Double: "DOUBLE PRECISION",
-            QVariant.Bool: "BOOLEAN",
+            QMetaType.Type.QString: "VARCHAR(MAX)",
+            QMetaType.Type.Int: "BIGINT",
+            QMetaType.Type.LongLong: "BIGINT",
+            QMetaType.Type.Double: "DOUBLE PRECISION",
+            QMetaType.Type.Bool: "BOOLEAN",
             "geometry": "GEOMETRY",
         },
         "postgres": {
-            QVariant.String: "TEXT",
-            QVariant.Int: "INTEGER",
-            QVariant.LongLong: "BIGINT",
-            QVariant.Double: "DOUBLE PRECISION",
-            QVariant.Bool: "BOOLEAN",
+            QMetaType.Type.QString: "TEXT",
+            QMetaType.Type.Int: "INTEGER",
+            QMetaType.Type.LongLong: "BIGINT",
+            QMetaType.Type.Double: "DOUBLE PRECISION",
+            QMetaType.Type.Bool: "BOOLEAN",
             "geometry": "GEOMETRY",
         },
         "databricksRest": {
-            QVariant.String: "VARCHAR",
-            QVariant.Int: "BIGINT",
-            QVariant.LongLong: "BIGINT",
-            QVariant.Double: "DOUBLE",
-            QVariant.Bool: "BOOLEAN",
+            QMetaType.Type.QString: "VARCHAR",
+            QMetaType.Type.Int: "BIGINT",
+            QMetaType.Type.LongLong: "BIGINT",
+            QMetaType.Type.Double: "DOUBLE",
+            QMetaType.Type.Bool: "BOOLEAN",
             "geometry": "STRING",
         },
     }
@@ -207,7 +207,7 @@ def set_proxy_values(session):
         if proxyType != "HttpProxy":
             QgsMessageLog.logMessage(
                 "Carto: Only HttpProxy is supported " "for connecting to the Carto API",
-                level=Qgis.Warning,
+                level=Qgis.MessageLevel.Warning,
             )
             return
 
@@ -236,8 +236,8 @@ def set_proxy_values(session):
         session.proxies = {}
 
 
-def log(message, level=Qgis.Info):
-    if level == Qgis.Info:
+def log(message, level=Qgis.MessageLevel.Info):
+    if level == Qgis.MessageLevel.Info:
         QgsMessageLog.logMessage(message, "CARTO", level)
     else:
         if setting(ENABLE_LOG):

--- a/carto/gui/authorization_manager.py
+++ b/carto/gui/authorization_manager.py
@@ -115,7 +115,7 @@ class AuthorizationManager(QObject):
         process
         """
         dlg = AuthorizeDialog(iface.mainWindow())
-        if dlg.exec_():
+        if dlg.exec():
             self.start_authorization_workflow(dlg.sso_org)
         else:
             self.queued_callbacks = []
@@ -151,7 +151,7 @@ class AuthorizationManager(QObject):
         button.setText("Cancel")
         button.pressed.connect(button_clicked)
         self._authorizing_message.layout().addWidget(button)
-        iface.messageBar().pushWidget(self._authorizing_message, Qgis.Info)
+        iface.messageBar().pushWidget(self._authorizing_message, Qgis.MessageLevel.Info)
 
         self._workflow.start()
         return False
@@ -210,7 +210,7 @@ class AuthorizationManager(QObject):
         self.authorized.emit()
 
         dlg = AuthorizationSuccessDialog(iface.mainWindow())
-        dlg.exec_()
+        dlg.exec()
         if dlg.logout:
             self.deauthorize()
 

--- a/carto/gui/authorizedialog.py
+++ b/carto/gui/authorizedialog.py
@@ -44,7 +44,7 @@ class AuthorizeDialog(BASE, WIDGET):
 
     def login_sso(self):
         dlg = SSODialog(self)
-        if dlg.exec_():
+        if dlg.exec():
             name = dlg.sso_org
             session = requests.Session()
             set_proxy_values(session)
@@ -59,7 +59,7 @@ class AuthorizeDialog(BASE, WIDGET):
                 else:
                     log(
                         f"Invalid organization name: {name}. Response: {response.text}",
-                        Qgis.Critical,
+                        Qgis.MessageLevel.Critical,
                     )
                     QMessageBox.warning(
                         self, "Invalid organization", "Invalid organization name"
@@ -74,7 +74,7 @@ class AuthorizeDialog(BASE, WIDGET):
                 stacktrace = traceback.format_exc()
                 log(
                     f"Error resolving organization name: {stacktrace}",
-                    Qgis.Critical,
+                    Qgis.MessageLevel.Critical,
                 )
                 QMessageBox.warning(
                     self,

--- a/carto/gui/config_dialog.py
+++ b/carto/gui/config_dialog.py
@@ -29,7 +29,6 @@ class CartoOptionsPage(QgsOptionsPageWidget):
         self.config_widget = ConfigDialog()
         layout = QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.setMargin(0)
         self.setLayout(layout)
         layout.addWidget(self.config_widget)
         self.setObjectName("cartoOptions")

--- a/carto/gui/dataitemprovider.py
+++ b/carto/gui/dataitemprovider.py
@@ -1,4 +1,4 @@
-import sip
+from qgis.PyQt import sip
 from json2html import json2html
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QAction, QDialog
@@ -210,8 +210,8 @@ class SchemaItem(QgsDataCollectionItem):
             self.schema,
             iface.mainWindow(),
         )
-        ret = dialog.exec_()
-        if ret == QDialog.Accepted:
+        ret = dialog.exec()
+        if ret == QDialog.DialogCode.Accepted:
             dialog.schema.import_table(
                 dialog.file_or_layer,
                 dialog.tablename,
@@ -268,8 +268,8 @@ class TableItem(QgsDataItem):
             self.table, self.table.schema.database.connection
         )
         dlg.show()
-        ret = dlg.exec_()
-        if ret == QDialog.Accepted:
+        ret = dlg.exec()
+        if ret == QDialog.DialogCode.Accepted:
             self._add_layer(dlg.where, dlg.limit)
 
     def add_layer(self):
@@ -284,7 +284,7 @@ class TableItem(QgsDataItem):
         def _show_terminated_message():
             iface.messageBar().pushMessage(
                 f"Layer download failed or was canceled ({self.table.name})",
-                level=Qgis.Warning,
+                level=Qgis.MessageLevel.Warning,
                 duration=5,
             )
 
@@ -298,7 +298,7 @@ class TableItem(QgsDataItem):
         iface.messageBar().pushMessage(
             "",
             "Download task added to QGIS task manager",
-            level=Qgis.Info,
+            level=Qgis.MessageLevel.Info,
             duration=5,
         )
 
@@ -307,7 +307,7 @@ class TableItem(QgsDataItem):
         if layer is None:
             iface.messageBar().pushMessage(
                 "The query didn't yield any data to download",
-                level=Qgis.Warning,
+                level=Qgis.MessageLevel.Warning,
                 duration=10,
             )
             return
@@ -318,7 +318,7 @@ class TableItem(QgsDataItem):
             iface.messageBar().pushMessage(
                 "Read-only",
                 "No permission to write. Local changes will not be saved to the original table",
-                level=Qgis.Warning,
+                level=Qgis.MessageLevel.Warning,
                 duration=10,
             )
             return

--- a/carto/gui/downloadfilteredlayerdialog.py
+++ b/carto/gui/downloadfilteredlayerdialog.py
@@ -34,7 +34,7 @@ class DownloadFilteredLayerDialog(BASE, WIDGET):
         self.limit = None
         self.connection = connection
         self.bar = QgsMessageBar()
-        self.bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        self.bar.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
         self.layout().addWidget(self.bar)
 
         self.buttonBox.accepted.connect(self.okClicked)
@@ -48,7 +48,7 @@ class DownloadFilteredLayerDialog(BASE, WIDGET):
         if self.grpSpatialFilter.isChecked():
             extent = self.extentPanel.getExtent()
             if extent is None:
-                self.bar.pushMessage("Invalid extent value", Qgis.Warning, duration=5)
+                self.bar.pushMessage("Invalid extent value", Qgis.MessageLevel.Warning, duration=5)
                 return
             destination_crs = QgsCoordinateReferenceSystem("EPSG:4326")
             transform = QgsCoordinateTransform(
@@ -90,7 +90,7 @@ class DownloadFilteredLayerDialog(BASE, WIDGET):
         elif self.grpWhereFilter.isChecked():
             statements.append(self.txtWhere.text())
         elif not self.grpLimit.isChecked():
-            self.bar.pushMessage("Please select a filter", Qgis.Warning, duration=5)
+            self.bar.pushMessage("Please select a filter", Qgis.MessageLevel.Warning, duration=5)
             return
         else:
             statements.append("TRUE")
@@ -99,13 +99,13 @@ class DownloadFilteredLayerDialog(BASE, WIDGET):
             limit = self.txtLimit.text()
             if not limit:
                 self.bar.pushMessage(
-                    "Maximum number of rows is required", Qgis.Warning, duration=5
+                    "Maximum number of rows is required", Qgis.MessageLevel.Warning, duration=5
                 )
                 return
             try:
                 self.limit = int(limit)
             except ValueError:
-                self.bar.pushMessage("Invalid number of rows", Qgis.Warning, duration=5)
+                self.bar.pushMessage("Invalid number of rows", Qgis.MessageLevel.Warning, duration=5)
                 return
         else:
             self.limit = MAX_ROWS

--- a/carto/gui/extentselectionpanel.py
+++ b/carto/gui/extentselectionpanel.py
@@ -54,11 +54,11 @@ class ExtentSelectionPanel(BASE, WIDGET):
         useLayerExtentAction.triggered.connect(self.useLayerExtent)
         useCanvasExtentAction.triggered.connect(self.useCanvasExtent)
 
-        popupmenu.exec_(QCursor.pos())
+        popupmenu.exec(QCursor.pos())
 
     def useLayerExtent(self):
         dlg = LayerSelectionDialog(self)
-        if dlg.exec_():
+        if dlg.exec():
             layer = dlg.selected_layer()
             self.setValueFromRect(QgsReferencedRectangle(layer.extent(), layer.crs()))
 

--- a/carto/gui/importdialog.py
+++ b/carto/gui/importdialog.py
@@ -19,7 +19,7 @@ class ImportDialog(BASE, WIDGET):
         self.setupUi(self)
 
         self.bar = QgsMessageBar()
-        self.bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        self.bar.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
         self.layout().addWidget(self.bar)
 
         self.buttonBox.accepted.connect(self.okClicked)
@@ -69,7 +69,7 @@ class ImportDialog(BASE, WIDGET):
         else:
             self.file_or_layer = self.txtFile.filePath()
         if not self.file_or_layer:
-            self.bar.pushMessage("File or layer is required", Qgis.Warning, duration=5)
+            self.bar.pushMessage("File or layer is required", Qgis.MessageLevel.Warning, duration=5)
             return
         self.tablename = self.txtTablename.text()
         if not self.tablename:

--- a/carto/gui/settingsdialog.py
+++ b/carto/gui/settingsdialog.py
@@ -17,7 +17,7 @@ class SettingsDialog(BASE, WIDGET):
         self.setupUi(self)
 
         self.bar = QgsMessageBar()
-        self.bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        self.bar.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
         self.layout().addWidget(self.bar)
 
         self.buttonBox.accepted.connect(self.okClicked)

--- a/carto/gui/utils.py
+++ b/carto/gui/utils.py
@@ -9,7 +9,7 @@ from qgis.core import Qgis, QgsMessageLog
 def waitcursor(method):
     def func(*args, **kw):
         try:
-            QApplication.setOverrideCursor(Qt.WaitCursor)
+            QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
             return method(*args, **kw)
         except Exception as ex:
             raise ex

--- a/carto/metadata.txt
+++ b/carto/metadata.txt
@@ -1,6 +1,6 @@
 [general]
 name=CARTO
-qgisMinimumVersion=3.16
+qgisMinimumVersion=4.0
 description=Seamless Cloud Data Warehouse Integration
 about=The CARTO QGIS Plugin allows you to access, visualize, and edit spatial data from leading cloud data warehouses directly within QGIS. With this plugin, you can seamlessly check out data from Google BigQuery, Snowflake, Databricks, AWS Redshift, and PostgreSQL, edit it within QGIS, and commit changes back to your data warehouse—all powered by the CARTO platform.
 

--- a/carto/plugin.py
+++ b/carto/plugin.py
@@ -80,7 +80,7 @@ class CartoPlugin(object):
             try:
                 CARTO_API.user()
                 dlg = AuthorizationSuccessDialog(iface.mainWindow())
-                dlg.exec_()
+                dlg.exec()
                 if dlg.logout:
                     AUTHORIZATION_MANAGER.deauthorize()
             except:

--- a/helper.py
+++ b/helper.py
@@ -76,18 +76,19 @@ def package(version=None):
 
 def install():
     src = os.path.join(os.path.dirname(__file__), "carto")
+    qgis_version = "QGIS4" if "--qgis4" in sys.argv else "QGIS3"
     if os.name == "nt":
         default_profile_plugins = (
-            "~/AppData/Roaming/QGIS/QGIS3/profiles/default/python/plugins"
+            f"~/AppData/Roaming/QGIS/{qgis_version}/profiles/default/python/plugins"
         )
     elif sys.platform == "darwin":
         default_profile_plugins = (
-            "~/Library/Application Support/QGIS/QGIS3"
+            f"~/Library/Application Support/QGIS/{qgis_version}"
             "/profiles/default/python/plugins"
         )
     else:
         default_profile_plugins = (
-            "~/.local/share/QGIS/QGIS3/profiles/default/python/plugins"
+            f"~/.local/share/QGIS/{qgis_version}/profiles/default/python/plugins"
         )
 
     dst_plugins = os.path.expanduser(default_profile_plugins)
@@ -127,14 +128,14 @@ def usage():
         (
             "Usage:\n"
             f"  {sys.argv[0]} package [VERSION]    Build a QGIS plugin zip file\n"
-            f"  {sys.argv[0]} install              Install in your local QGIS (for development)\n"
+            f"  {sys.argv[0]} install [--qgis4]    Install in your local QGIS (for development)\n"
         ),
         file=sys.stderr,
     )
     sys.exit(2)
 
 
-if len(sys.argv) == 2 and sys.argv[1] == "install":
+if len(sys.argv) >= 2 and sys.argv[1] == "install":
     install()
 elif len(sys.argv) in [2, 3] and sys.argv[1] == "package":
     package(*sys.argv[2:])


### PR DESCRIPTION
## Summary

- Migrate all Python code from PyQt5 to PyQt6 conventions for QGIS 4.0 compatibility
- Replace `exec_()` with `exec()`, qualify all enum references (`Qgis.MessageLevel.Info`, `Qt.CursorShape.*`, `QDialog.DialogCode.*`, `QSizePolicy.Policy.*`, etc.)
- Replace `QVariant` type constants with `QMetaType.Type` equivalents
- Fix bare `import sip` → `from qgis.PyQt import sip`
- Remove deprecated `layout.setMargin()` (redundant with `setContentsMargins`)
- Set `qgisMinimumVersion=4.0` in metadata.txt
- Add `--qgis4` flag to `helper.py install` for QGIS 4 plugin directory
- Update README, CONTRIBUTING, and CLAUDE.md for QGIS 4.0+ / Python 3.12+

Closes #10

## Test plan

- [x] Plugin loads in QGIS 4.0.3 without errors
- [x] Login / logout auth flow
- [x] Add layer from data warehouse
- [x] Add layer using filter (spatial/attribute/limit)
- [x] Import layer
- [x] Attribute edit and commit upstream
- [x] Create new point feature and commit upstream
- [x] Table info dialog
- [x] Settings dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)